### PR TITLE
Generate a fake Bluetooth alert

### DIFF
--- a/Permissions/CalAlertFactory.h
+++ b/Permissions/CalAlertFactory.h
@@ -9,5 +9,6 @@
 - (UIAlertView *) alertForFacebookNYI;
 - (UIAlertView *) alertForHomeKitNYI;
 - (UIAlertView *) alertForHealthKitNYI;
+- (UIAlertView *) alertForBluetoothFAKE;
 
 @end

--- a/Permissions/CalAlertFactory.m
+++ b/Permissions/CalAlertFactory.m
@@ -70,4 +70,19 @@
   return [self alertForNYIWithMessage:[self healthKitMessage]];
 }
 
+// We have not been able to generate a Bluetooth alert, but we have one example
+// in English.
+- (UIAlertView *) alertForBluetoothFAKE {
+  NSString *title = @"APP NAME would like to make data available to nearby bluetooth devices even when you're not using the app";
+  NSString *no = @"Don't Allow";
+  NSString *ok = @"OK";
+
+  return [[UIAlertView alloc]
+          initWithTitle:title
+          message:nil
+          delegate:self.delegate
+          cancelButtonTitle:no
+          otherButtonTitles:ok, nil];
+}
+
 @end

--- a/Permissions/ViewController.m
+++ b/Permissions/ViewController.m
@@ -177,6 +177,10 @@ typedef enum : NSInteger {
 - (void) rowTouchedBluetooth {
   NSLog(@"Bluetooth Sharing is requested");
 
+  [[self.alertFactory alertForBluetoothFAKE] show];
+
+  /* Have not been able to generate a Bluetooth alert reliably, so we'll
+     generate a fake one with the same title.
   if (!self.cbManager) {
     self.cbManager = [[CBCentralManager alloc]
                       initWithDelegate:self
@@ -185,6 +189,7 @@ typedef enum : NSInteger {
   }
 
   [self.cbManager scanForPeripheralsWithServices:nil options:nil];
+  */
 }
 
 #pragma mark - Row Touched: Microphone

--- a/features/permissions.feature
+++ b/features/permissions.feature
@@ -32,12 +32,10 @@ Scenario: Photos alert is dismissed
   Then Calabash should dismiss the alert
   And I see the photo roll
 
-@not_xtc
-@pending
 @bluetooth
 Scenario: Bluetooth Sharing alert
   When I touch the Bluetooth Sharing row
-  Then I am waiting to figure out how to generate a Bluetooth alert
+  Then Calabash should dismiss the alert
 
 @device
 @microphone

--- a/features/steps/shared_steps.rb
+++ b/features/steps/shared_steps.rb
@@ -27,8 +27,8 @@ And(/^I see the photo roll$/) do
   wait_for_view("view marked:'Photos'")
 end
 
-Then(/^I am waiting to figure out how to generate a (Bluetooth|Microphone) alert$/) do |type|
-  message = "Cannot reliably generate a '#{type}' alert yet. :("
+Then(/^I am waiting to figure out how to generate a Microphone alert$/) do
+  message = "Cannot reliably generate a 'Microphone' alert yet. :("
   pending(message)
 end
 


### PR DESCRIPTION
### Motivation

**Unable to touch buttons on OS level permission alerts** [#324](https://github.com/calabash/run_loop/issues/324)

We have not been able to reliably generate Bluetooth alerts.  This PR will generate an alert with the same _title_ and tests whether the alert has been auto-dismissed.