### PR TITLE
Tests for dismissing Apple Push Notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ xtc-submit
 ## Build products
 build/*
 */build/*
+tmp

--- a/.irbrc
+++ b/.irbrc
@@ -126,17 +126,12 @@ def start_danish(options={})
   sim = default_sim
   RunLoop::CoreSimulator.erase(sim)
 
-  path = File.expand_path(File.join(sim.simulator_preferences_plist_path, "..", ".GlobalPreferences.plist"))
-  pbuddy = RunLoop::PlistBuddy.new
-  pbuddy.plist_set("AppleLocale", "string", "da_DA", path)
-
-  xcrun = RunLoop::Xcrun.new
-  cmd = ["PlistBuddy", "-c", "Add :AppleLanguages:0 string 'da'", path]
-  xcrun.exec(cmd, {:log_cmd => true})
+  RunLoop::CoreSimulator.set_locale(sim, "da")
+  RunLoop::CoreSimulator.set_language(sim, "da")
 
   launch_options = {
     :uia_strategy => :preferences,
-    :args => ["-AppleLanguages", "(da)", "-AppleLocale da_DA"],
+    :args => ["-AppleLanguages", "(da)", "-AppleLocale da"],
   }.merge(options)
   start_test_server_in_background(launch_options)
 end
@@ -145,17 +140,12 @@ def start_dutch(options={})
   sim = default_sim
   RunLoop::CoreSimulator.erase(sim)
 
-  path = File.expand_path(File.join(sim.simulator_preferences_plist_path, "..", ".GlobalPreferences.plist"))
-  pbuddy = RunLoop::PlistBuddy.new
-  pbuddy.plist_set("AppleLocale", "string", "nl_NL", path)
-
-  xcrun = RunLoop::Xcrun.new
-  cmd = ["PlistBuddy", "-c", "Add :AppleLanguages:0 string 'nl'", path]
-  xcrun.exec(cmd, {:log_cmd => true})
+  RunLoop::CoreSimulator.set_locale(sim, "nl")
+  RunLoop::CoreSimulator.set_language(sim, "nl")
 
   launch_options = {
     :uia_strategy => :preferences,
-    :args => ["-AppleLanguages", "(nl)", "-AppleLocale nl_NL"],
+    :args => ["-AppleLanguages", "(nl)", "-AppleLocale nl"],
   }.merge(options)
   start_test_server_in_background(launch_options)
 end

--- a/.irbrc
+++ b/.irbrc
@@ -112,6 +112,16 @@ def start_en(options={})
   start_test_server_in_background(launch_options)
 end
 
+def World(mod)
+  puts "Worlding module: #{mod}"
+  include mod
+end
+
+load("features/0x/support/2x-bridge.rb")
+load("features/0x/support/wait_for_alert.rb")
+load("features/0x/support/tap_row.rb")
+load("features/support/alerts.rb")
+
 def start_danish(options={})
   sim = default_sim
   RunLoop::CoreSimulator.erase(sim)

--- a/Permissions.xcodeproj/project.pbxproj
+++ b/Permissions.xcodeproj/project.pbxproj
@@ -190,6 +190,15 @@
 			attributes = {
 				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = Calabash;
+				TargetAttributes = {
+					92D569FC18A38F0300B4369B = {
+						SystemCapabilities = {
+							com.apple.Push = {
+								enabled = 1;
+							};
+						};
+					};
+				};
 			};
 			buildConfigurationList = 92D569F818A38F0300B4369B /* Build configuration list for PBXProject "Permissions" */;
 			compatibilityVersion = "Xcode 3.2";

--- a/Permissions.xcodeproj/project.pbxproj
+++ b/Permissions.xcodeproj/project.pbxproj
@@ -410,7 +410,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Permissions/Permissions-Prefix.pch";
 				INFOPLIST_FILE = "Permissions/Permissions-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -437,7 +437,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Permissions/Permissions-Prefix.pch";
 				INFOPLIST_FILE = "Permissions/Permissions-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "sh.calaba.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Permissions/ViewController.m
+++ b/Permissions/ViewController.m
@@ -33,6 +33,7 @@ typedef enum : NSInteger {
   kTwitter,
   kHomeKit,
   kHealthKit,
+  kAPNS,
   kNumberOfRows
 } CalTableRows;
 
@@ -69,6 +70,7 @@ typedef enum : NSInteger {
 - (void) rowTouchedTwitter;
 - (void) rowTouchedHomeKit;
 - (void) rowTouchedHealthKit;
+- (void) rowTouchedApns;
 
 @end
 
@@ -338,6 +340,18 @@ typedef enum : NSInteger {
   [[self.alertFactory alertForHealthKitNYI] show];
 }
 
+- (void) rowTouchedApns {
+  UIApplication *shared = [UIApplication sharedApplication];
+
+  UIUserNotificationType types = (UIUserNotificationTypeBadge |
+                                  UIUserNotificationTypeSound |
+                                  UIUserNotificationTypeAlert);
+  UIUserNotificationSettings *settings;
+  settings = [UIUserNotificationSettings settingsForTypes:types categories:nil];
+  [shared registerUserNotificationSettings:settings];
+  [shared registerForRemoteNotifications];
+}
+
 #pragma mark - <UITableViewDataSource>
 
 - (RowDetails *) detailsForRowAtIndexPath:(NSIndexPath *) path {
@@ -446,6 +460,13 @@ typedef enum : NSInteger {
       selector = @selector(rowTouchedHealthKit);
       title = @"Health Kit";
       identifier = @"health kit";
+      break;
+    }
+
+    case kAPNS: {
+      selector = @selector(rowTouchedApns);
+      title = @"APNS";
+      identifier = @"apns";
       break;
     }
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Permissions
 
-An app for displaying Privacy Alerts for iOS 7 and greater.
+An app for displaying Privacy Alerts for iOS 8 and greater.
 
 ### Build
 
@@ -21,11 +21,76 @@ built with the **Debug** configuration.
 $ be cucumber
 ```
 
+### Console
+
+```
+# Don't use the calabash-ios console
+$ be irb
+```
+
+### Use Permissions to Add New Localization
+
+You must use bundler's ability to run from local sources.
+
+```
+$ cd ~/git/calabash
+$ git clone < run loop >
+$ bundle config local.run_loop ~/git/calabash/run_loop
+```
+
+In this repo's Gemfile, you will see:
+
+```
+gem "run_loop", :github => "calabash/run_loop", :branch => "develop"
+```
+
+When running in the context of bundle exec, bundler will use local
+sources for run\_loop.
+
+Open ~/git/calabash/run\_loop/scripts/lib/on\_alert.js.
+
+Uncomment these two lines:
+
+```
+  var buttonNames = findAlertButtonNames(alert);
+  Log.output({"output":"alert: " + title + "," + buttonNames}, true);
+```
+
+and save.
+
+Find the two letter language and locale codes.  We'll use French as our
+example.
+
+```
+$ bundle update
+$ APP_LANG=fr APP_LOCALE=fr bundle exec cucumber -t ~@motion
+```
+
+Tests will fail, but a file will be generated in ~/tmp/ that contains
+lines like this:
+
+```
+# Alert title, left button title, right button title
+{"output":{"output":"alert: « Permissions » souhaite accéder à vos photos.,Refuser,OK"},"last_index":0}
+```
+
+Extract the alert title and accept button title and add them to
+scripts/lib/on\_alert.js.
+
+The motion tests need to be run separately because the alert is
+completely blocking.
+
+```
+$ APP_LANG=fr APP_LOCALE=fr bundle exec cucumber -t @motion
+```
+
+The alert title and button tiles will be printed to stdout.  Because
+this alert is 100% blocking, no file will be written.
+
 ### TODO
 
 - [ ] Health Kit
 - [ ] Home Kit
 - [ ] Cannot get a Bluetooth Sharing alert to pop
 - [ ] Cannot get a Microphone alert to pop on iOS Simulators
-- [ ] Run on XTC - must wait for Calabash 2.0 support on XTC
 

--- a/bin/test/test-cloud.rb
+++ b/bin/test/test-cloud.rb
@@ -11,7 +11,7 @@ if !device_set || device_set == ""
 end
 
 if !device_set || device_set == ""
-  device_set = ["086866b4", "19dc29ac", "0dea10e8", "a044021a"].sample
+  device_set = ["35d0da97", "2c9fc4b1", "0a3b9ecb", "331ab3d4"].sample
 end
 
 if !Luffa::Environment.travis_ci? && !Luffa::Environment.jenkins_ci?

--- a/features/0x/support/01_launch.rb
+++ b/features/0x/support/01_launch.rb
@@ -144,18 +144,20 @@ end
 
 After do |_|
 
-  alert_results_file = LaunchControl.alert_results_file
-  run_loop = LaunchControl.launcher.run_loop
+  if !xamarin_test_cloud?
+    alert_results_file = LaunchControl.alert_results_file
+    run_loop = LaunchControl.launcher.run_loop
 
-  if run_loop
-    log_file = run_loop[:log_file]
-    lines = File.read(log_file).force_encoding("UTF-8")
-    lines.split($-0).each do |line|
-      if line[/alert:/, 0]
-        puts "#{line}"
-        $stdout.flush
-        File.open(alert_results_file, "a:UTF-8") do |file|
-          file.puts(line)
+    if run_loop
+      log_file = run_loop[:log_file]
+      lines = File.read(log_file).force_encoding("UTF-8")
+      lines.split($-0).each do |line|
+        if line[/alert:/, 0]
+          puts "#{line}"
+          $stdout.flush
+          File.open(alert_results_file, "a:UTF-8") do |file|
+            file.puts(line)
+          end
         end
       end
     end

--- a/features/0x/support/01_launch.rb
+++ b/features/0x/support/01_launch.rb
@@ -4,6 +4,7 @@ module LaunchControl
 
   @@launcher = nil
   @@is_first_launch = true
+  @@alert_results_file = nil
 
   def self.launcher
     @@launcher ||= Calabash::Cucumber::Launcher.new
@@ -13,9 +14,20 @@ module LaunchControl
     @@launcher = launcher
   end
 
+  def self.alert_results_file
+    @@alert_results_file
+  end
+
   def self.reset_before_any_tests
     if @@is_first_launch
       if self.target_is_simulator?
+        FileUtils.mkdir_p("tmp")
+        @@alert_results_file = "tmp/alert_text_#{LaunchControl.app_lang}.txt"
+        if File.exist?(@@alert_results_file)
+          FileUtils.rm_r(@@alert_results_file)
+        end
+
+        FileUtils.touch(@@alert_results_file)
         self.reset_simulator
       else
 
@@ -132,5 +144,21 @@ end
 
 After do |_|
 
+  alert_results_file = LaunchControl.alert_results_file
+  run_loop = LaunchControl.launcher.run_loop
+
+  if run_loop
+    log_file = run_loop[:log_file]
+    lines = File.read(log_file).force_encoding("UTF-8")
+    lines.split($-0).each do |line|
+      if line[/alert:/, 0]
+        puts "#{line}"
+        $stdout.flush
+        File.open(alert_results_file, "a:UTF-8") do |file|
+          file.puts(line)
+        end
+      end
+    end
+  end
 end
 

--- a/features/0x/support/01_launch.rb
+++ b/features/0x/support/01_launch.rb
@@ -116,8 +116,9 @@ Before do |_|
         "-AppleLocale", LaunchControl.app_locale
       ],
 
-      #:uia_strategy => :host
-      #:uia_strategy => :shared_element
+      #:uia_strategy => :preferences,
+      #:uia_strategy => :host,
+      #:uia_strategy => :shared_element,
       :uia_strategy => strategy
   }
 

--- a/features/0x/support/01_launch.rb
+++ b/features/0x/support/01_launch.rb
@@ -95,7 +95,7 @@ Before('@reset_device_settings') do
   end
 end
 
-Before do |scenario|
+Before do |_|
   if !xamarin_test_cloud?
     LaunchControl.reset_before_any_tests
   end

--- a/features/permissions.feature
+++ b/features/permissions.feature
@@ -68,3 +68,8 @@ Scenario: Camera alert is not dismissed
   When I touch the Camera row
   Then Calabash should dismiss the alert
 
+@apns
+Scenario: Apple Push Notification Services
+  When I touch the APNS row
+  Then Calabash should dismiss the alert
+

--- a/features/permissions.feature
+++ b/features/permissions.feature
@@ -39,6 +39,11 @@ Scenario: Photos alert is dismissed
   Then Calabash should dismiss the alert
   And I see the photo roll
 
+@twitter
+Scenario:  Twitter alert is dismissed
+  When I touch the Twitter row
+  Then Calabash should dismiss the alert
+
 @bluetooth
 Scenario: Bluetooth Sharing alert
   When I touch the Bluetooth Sharing row

--- a/features/steps/shared_steps.rb
+++ b/features/steps/shared_steps.rb
@@ -3,7 +3,11 @@ Given(/^I can see the list of services requiring authorization$/) do
   wait_for_view("view marked:'table'")
 end
 
-When(/^I touch the (Facebook|Contacts|Calendar|Reminders|Photos|Camera|Microphone) row$/) do |row|
+When(/^I touch the (Contacts|Calendar|Reminders|Photos|Camera|Microphone) row$/) do |row|
+  tap_row(row.downcase)
+end
+
+When(/^I touch the (Facebook|Twitter) row$/) do |row|
   tap_row(row.downcase)
 end
 

--- a/features/steps/shared_steps.rb
+++ b/features/steps/shared_steps.rb
@@ -40,3 +40,32 @@ When(/^I touch the APNS row$/) do
   tap_row("apns")
 end
 
+Then(/^an NYI alert is presented$/) do
+  expect(alert_title).to be == 'Not Implemented'
+end
+
+Then(/^Calabash does not dismiss the alert$/) do
+  # See the comments below.
+  begin
+    with_timeout(3.0, 'Ignored') { uia_with_app('alert()') }
+    fail("Expected a Privacy Alert to be showing. Such alerts block UIA traffic")
+  rescue Calabash::IOS::RouteError => _
+  end
+end
+
+Then(/^Calabash should dismiss the alert$/) do
+  # In a previous implementation, I was able to demonstrate that the first
+  # UIA query after the `onAlert()` call will _time out_, regardless of
+  # whether or not the alert is dismissed.
+  # https://github.com/calabash/calabash/issues/277
+  # Calabash::Device.default.send(:uia_serialize_and_call, :query, 'window')
+
+  # If a Privacy Alert is showing, all UIAutomation traffic is blocked.
+  # query will still work because it does not interact with UIAutomation.
+  #
+  # If the UIA call times out, then there is probably a privacy alert.
+  timeout = 3.0
+  message = "Timed out after #{timeout} seconds waiting for alert to be dismissed"
+  with_timeout(timeout, message) { uia_with_app('alert()') }
+end
+

--- a/features/steps/shared_steps.rb
+++ b/features/steps/shared_steps.rb
@@ -36,3 +36,7 @@ Then(/^I am waiting to figure out how to generate a Microphone alert$/) do
   pending(message)
 end
 
+When(/^I touch the APNS row$/) do
+  tap_row("apns")
+end
+

--- a/features/support/alerts.rb
+++ b/features/support/alerts.rb
@@ -114,32 +114,3 @@ end
 
 World(Permissions::Alerts)
 
-Then(/^an NYI alert is presented$/) do
-  expect(alert_title).to be == 'Not Implemented'
-end
-
-Then(/^Calabash does not dismiss the alert$/) do
-  # See the comments below.
-  begin
-    with_timeout(3.0, 'Ignored') { uia_with_app('alert()') }
-    fail("Expected a Privacy Alert to be showing. Such alerts block UIA traffic")
-  rescue Calabash::IOS::RouteError => _
-  end
-end
-
-Then(/^Calabash should dismiss the alert$/) do
-  # In a previous implementation, I was able to demonstrate that the first
-  # UIA query after the `onAlert()` call will _time out_, regardless of
-  # whether or not the alert is dismissed.
-  # https://github.com/calabash/calabash/issues/277
-  # Calabash::Device.default.send(:uia_serialize_and_call, :query, 'window')
-
-  # If a Privacy Alert is showing, all UIAutomation traffic is blocked.
-  # query will still work because it does not interact with UIAutomation.
-  #
-  # If the UIA call times out, then there is probably a privacy alert.
-  timeout = 3.0
-  message = "Timed out after #{timeout} seconds waiting for alert to be dismissed"
-  with_timeout(timeout, message) { uia_with_app('alert()') }
-end
-


### PR DESCRIPTION
### Motivation

* **No french localization for handling system dialogs like permissions** [#369](https://github.com/calabash/run_loop/pull/377)
* **run-loop: release - version TBD** [#93](https://github.com/xamarinhq/test-cloud-frameworks/issues/93)

Also!

* Update the docs with instructions about how to generate regexes for a new localization.
* Add Twitter test (missing for some reason)
* Add support for launching in a new language or locale

```
$ APP_LANG=da APP_LOCALE=da be cucumber
```

ATTN @Oddj0b @krukow 

* [XTC Run](https://testcloud.xamarin.com/test/permissions_1ca0a845-ca6f-4977-b90b-a5b809dd3b83/)