### PR TITLE
Enable HealthKit and add Cucumbers for dismissing the modal permissions view

### DIFF
--- a/Permissions.xcodeproj/project.pbxproj
+++ b/Permissions.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		F500E66F1B8DF42D00AA9A03 /* CalAlertFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = F500E66E1B8DF42D00AA9A03 /* CalAlertFactory.m */; };
 		F54CCC291B84D79C0007F68D /* RowDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = F54CCC281B84D79C0007F68D /* RowDetails.m */; };
 		F57605171BC57F6A00E89C97 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = F57605151BC57F6A00E89C97 /* LaunchScreen.xib */; };
+		F5F1A8E41C7B54BB00BF8D6F /* HealthKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F5F1A8E31C7B54BB00BF8D6F /* HealthKit.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -73,6 +74,8 @@
 		F56F07E61C15A06900A88CED /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Main.strings; sourceTree = "<group>"; };
 		F56F07E71C15A06900A88CED /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		F57605161BC57F6A00E89C97 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
+		F5F1A8E21C7B54BB00BF8D6F /* Permissions.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = Permissions.entitlements; sourceTree = "<group>"; };
+		F5F1A8E31C7B54BB00BF8D6F /* HealthKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = HealthKit.framework; path = System/Library/Frameworks/HealthKit.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -83,6 +86,7 @@
 				92D56A3B18A3945700B4369B /* CoreBluetooth.framework in Frameworks */,
 				92D56A3918A3944C00B4369B /* CoreLocation.framework in Frameworks */,
 				92D56A0318A38F0300B4369B /* CoreGraphics.framework in Frameworks */,
+				F5F1A8E41C7B54BB00BF8D6F /* HealthKit.framework in Frameworks */,
 				92D56A0518A38F0300B4369B /* UIKit.framework in Frameworks */,
 				92D56A0118A38F0300B4369B /* Foundation.framework in Frameworks */,
 			);
@@ -113,6 +117,7 @@
 		92D569FF18A38F0300B4369B /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				F5F1A8E31C7B54BB00BF8D6F /* HealthKit.framework */,
 				92917FF718CF72500095F2F7 /* CoreAudio.framework */,
 				92D56A3A18A3945700B4369B /* CoreBluetooth.framework */,
 				92D56A3818A3944C00B4369B /* CoreLocation.framework */,
@@ -126,7 +131,6 @@
 		92D56A0618A38F0300B4369B /* Permissions */ = {
 			isa = PBXGroup;
 			children = (
-				F57605141BC57F0B00E89C97 /* XIB */,
 				92D56A0F18A38F0300B4369B /* AppDelegate.h */,
 				92D56A1018A38F0300B4369B /* AppDelegate.m */,
 				92D56A1518A38F0300B4369B /* ViewController.h */,
@@ -136,6 +140,7 @@
 				F500E66D1B8DF42D00AA9A03 /* CalAlertFactory.h */,
 				F500E66E1B8DF42D00AA9A03 /* CalAlertFactory.m */,
 				92D56A1818A38F0300B4369B /* Images.xcassets */,
+				F57605141BC57F0B00E89C97 /* XIB */,
 				92D56A0718A38F0300B4369B /* Supporting Files */,
 			);
 			path = Permissions;
@@ -144,6 +149,7 @@
 		92D56A0718A38F0300B4369B /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				F5F1A8E21C7B54BB00BF8D6F /* Permissions.entitlements */,
 				92D56A0818A38F0300B4369B /* Permissions-Info.plist */,
 				92D56A0918A38F0300B4369B /* InfoPlist.strings */,
 				92D56A0C18A38F0300B4369B /* main.m */,
@@ -193,6 +199,9 @@
 				TargetAttributes = {
 					92D569FC18A38F0300B4369B = {
 						SystemCapabilities = {
+							com.apple.HealthKit = {
+								enabled = 1;
+							};
 							com.apple.Push = {
 								enabled = 1;
 							};
@@ -405,6 +414,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CODE_SIGN_ENTITLEMENTS = Permissions/Permissions.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -432,6 +442,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CODE_SIGN_ENTITLEMENTS = Permissions/Permissions.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;

--- a/Permissions/Base.lproj/Main.storyboard
+++ b/Permissions/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8173.3" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="14F1605" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
     <dependencies>
         <deployment identifier="iOS"/>
         <development version="6300" identifier="xcode"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8142"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -32,7 +32,7 @@
                             </tableView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
-                        <accessibility key="accessibilityConfiguration" identifier="page">
+                        <accessibility key="accessibilityConfiguration">
                             <bool key="isElement" value="YES"/>
                         </accessibility>
                         <constraints>

--- a/Permissions/CalAlertFactory.h
+++ b/Permissions/CalAlertFactory.h
@@ -8,7 +8,7 @@
 
 - (UIAlertView *) alertForFacebookNYI;
 - (UIAlertView *) alertForHomeKitNYI;
-- (UIAlertView *) alertForHealthKitNYI;
+- (UIAlertView *) alertForHealthKitNotSupported;
 - (UIAlertView *) alertForBluetoothFAKE;
 
 @end

--- a/Permissions/Permissions-Info.plist
+++ b/Permissions/Permissions-Info.plist
@@ -36,16 +36,12 @@
 	<string>Permissions wants to share your state-of-health with other apps.</string>
 	<key>NSHealthUpdateUsageDescription</key>
 	<string>Permissions wants to do something? With your health updates?</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>Permissions needs to know where you are ALWAYS.</string>
 	<key>NSLocationUsageDescription</key>
 	<string>Permissons need to use your location to spy on you.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Permissons need to use your location to spy on you.</string>
-	<key>NSLocationAlwaysUsageDescription</key>
-	<string>Permissions needs to know where you are ALWAYS.</string>
-	<key>UIBackgroundModes</key>
-	<array>
-		<string>location</string>
-	</array>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Permissions wants to record your conversations.</string>
 	<key>NSMotionUsageDescription</key>
@@ -54,6 +50,10 @@
 	<string>Permissions wants pictures of known associates.</string>
 	<key>NSRemindersUsageDescription</key>
 	<string>Permissions wants to bug you all the time.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>location</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -62,6 +62,7 @@
 	<array>
 		<string>location-services</string>
 		<string>armv7</string>
+		<string>healthkit</string>
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>

--- a/Permissions/Permissions.entitlements
+++ b/Permissions/Permissions.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.healthkit</key>
+	<true/>
+</dict>
+</plist>

--- a/Permissions/ViewController.m
+++ b/Permissions/ViewController.m
@@ -690,6 +690,7 @@ clickedButtonAtIndex:(NSInteger) buttonIndex {
 - (void) viewDidLoad {
   [super viewDidLoad];
 
+  self.view.accessibilityIdentifier = @"page";
   [self.table registerClass:[UITableViewCell class]
          forCellReuseIdentifier:CalCellIdentifier];
 }

--- a/Permissions/ViewController.m
+++ b/Permissions/ViewController.m
@@ -16,6 +16,22 @@
 #import "RowDetails.h"
 #import "CalAlertFactory.h"
 #import <objc/runtime.h>
+#import <HealthKit/HealthKit.h>
+
+@interface UIView (CalabashPermissions)
+
+- (BOOL) isHealthKitAvailable;
+
+@end
+
+@implementation UIView (CalabashPermissions)
+
+// HealthKit is avaiable on iOS > 7 and only on some devices
+- (BOOL) isHealthKitAvailable {
+  return NSClassFromString(@"HKHealthStore") && [HKHealthStore isHealthDataAvailable];
+}
+
+@end
 
 static NSString *const CalCellIdentifier = @"cell identifier";
 

--- a/Permissions/ViewController.m
+++ b/Permissions/ViewController.m
@@ -353,8 +353,39 @@ typedef enum : NSInteger {
 
 #pragma mark - Row Touched: Health Kit
 
+// http://jademind.com/blog/posts/healthkit-api-tutorial/
 - (void) rowTouchedHealthKit {
-  [[self.alertFactory alertForHealthKitNotSupported] show];
+  if ([[self view] isHealthKitAvailable]) {
+    HKHealthStore *healthStore = [[HKHealthStore alloc] init];
+
+    // Share body mass, height and body mass index
+    NSSet *shareObjectTypes = [NSSet setWithObjects:
+                               [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierBodyMass],
+                               [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierHeight],
+                               [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierBodyMassIndex],
+                               nil];
+
+    // Read date of birth, biological sex and step count
+    NSSet *readObjectTypes  = [NSSet setWithObjects:
+                               [HKObjectType characteristicTypeForIdentifier:HKCharacteristicTypeIdentifierDateOfBirth],
+                               [HKObjectType characteristicTypeForIdentifier:HKCharacteristicTypeIdentifierBiologicalSex],
+                               [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierStepCount],
+                               nil];
+
+    // Request access
+    [healthStore requestAuthorizationToShareTypes:shareObjectTypes
+                                        readTypes:readObjectTypes
+                                       completion:^(BOOL success, NSError *error) {
+                                         if (success) {
+                                           NSLog(@"Successfully enabled HealthKit");
+                                         } else {
+                                           NSLog(@"Did not enable HealthKit: %@",
+                                                 [error localizedDescription]);
+                                         }
+                                       }];
+  } else {
+   [[self.alertFactory alertForHealthKitNotSupported] show];
+  }
 }
 
 - (void) rowTouchedApns {

--- a/Permissions/ViewController.m
+++ b/Permissions/ViewController.m
@@ -338,7 +338,7 @@ typedef enum : NSInteger {
 #pragma mark - Row Touched: Health Kit
 
 - (void) rowTouchedHealthKit {
-  [[self.alertFactory alertForHealthKitNYI] show];
+  [[self.alertFactory alertForHealthKitNotSupported] show];
 }
 
 - (void) rowTouchedApns {

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ this alert is 100% blocking, no file will be written.
 
 ### TODO
 
-- [ ] Health Kit
+- [ ] Facebook
 - [ ] Home Kit
 - [ ] Cannot get a Bluetooth Sharing alert to pop
 - [ ] Cannot get a Microphone alert to pop on iOS Simulators

--- a/features/0x/support/2x-bridge.rb
+++ b/features/0x/support/2x-bridge.rb
@@ -82,6 +82,21 @@ to match a view"
         fail(message)
       end
     end
+
+    def wait_for(timeout_message, options={}, &block)
+      wait_options = @@default_options.merge(options)
+      timeout = wait_options[:timeout]
+
+      with_timeout(timeout, timeout_message, wait_options[:exception_class]) do
+        loop do
+          value = block.call
+
+          return value if value
+
+          sleep(wait_options[:retry_frequency])
+        end
+      end
+    end
   end
 end
 

--- a/features/0x/support/2x-bridge.rb
+++ b/features/0x/support/2x-bridge.rb
@@ -3,7 +3,8 @@ module Permissions
 
     @@default_options = {
         timeout: 8.0,
-        retry_frequency: 0.1
+        retry_frequency: 0.1,
+        exception_class: Timeout::Error
      }
 
     def wait_for_view(query, options={})
@@ -83,11 +84,12 @@ to match a view"
       end
     end
 
-    def wait_for(timeout_message, options={}, &block)
+    def bridge_wait_for(timeout_message, options={}, &block)
       wait_options = @@default_options.merge(options)
       timeout = wait_options[:timeout]
 
-      with_timeout(timeout, timeout_message, wait_options[:exception_class]) do
+      exception_class = wait_options[:exception_class]
+      with_timeout(timeout, timeout_message, exception_class) do
         loop do
           value = block.call
 

--- a/features/0x/support/wait_for_alert.rb
+++ b/features/0x/support/wait_for_alert.rb
@@ -1,7 +1,14 @@
 module Permissions
   module Alerts
     def wait_for_alert
-      timeout = 4
+      if RunLoop::Environment.ci?
+        timeout = 20.0
+      elsif RunLoop::Environment.xtc?
+        timeout = 10.0
+      else
+        timeout = 4.0
+      end
+
       message = "Waited #{timeout} seconds for an alert to appear"
       wait_for({:timeout => timeout, :timeout_message => message}) do
         alert_exists?

--- a/features/health_kit.feature
+++ b/features/health_kit.feature
@@ -4,7 +4,6 @@ In order to make testing Health Kit interactions easier
 As a developer
 I want an example of Calabash dismissng a Health Kit dialog
 
-@wip
 Scenario: Enabling Health Kit permissions
   Given I can see the list of services requiring authorization
   When I touch the Health Kit row

--- a/features/health_kit.feature
+++ b/features/health_kit.feature
@@ -2,11 +2,12 @@
 Feature: Health Kit Permissions
 In order to make testing Health Kit interactions easier
 As a developer
-I want Calabash to automatically dismiss Health Kit alerts
+I want an example of Calabash dismissng a Health Kit dialog
 
-@not_xtc
 @wip
-Scenario: Health Kit privacy alerts are not handled yet
+Scenario: Health Kit privacy alerts can be dismissed, but not automatically
   Given I can see the list of services requiring authorization
   When I touch the Health Kit row
-  Then a Not Supported alert is presented
+  Then I see the HealthKit modal view or Not Supported alert
+  And Calabash should enable all categories and allow
+

--- a/features/health_kit.feature
+++ b/features/health_kit.feature
@@ -5,8 +5,8 @@ As a developer
 I want Calabash to automatically dismiss Health Kit alerts
 
 @not_xtc
+@wip
 Scenario: Health Kit privacy alerts are not handled yet
   Given I can see the list of services requiring authorization
   When I touch the Health Kit row
-  Then an NYI alert is presented
-
+  Then a Not Supported alert is presented

--- a/features/health_kit.feature
+++ b/features/health_kit.feature
@@ -5,9 +5,9 @@ As a developer
 I want an example of Calabash dismissng a Health Kit dialog
 
 @wip
-Scenario: Health Kit privacy alerts can be dismissed, but not automatically
+Scenario: Enabling Health Kit permissions
   Given I can see the list of services requiring authorization
   When I touch the Health Kit row
   Then I see the HealthKit modal view or Not Supported alert
-  And Calabash should enable all categories and allow
+  Then I can enable HealthKit permissions and dismiss the page
 

--- a/features/steps/health_kit_steps.rb
+++ b/features/steps/health_kit_steps.rb
@@ -2,7 +2,7 @@
 Then(/^I see the HealthKit modal view or Not Supported alert$/) do
   if @supports_health_kit
     message = "Expected Health Access permissions view to appear"
-    wait_for(message) do
+    bridge_wait_for(message) do
       !uia_query(:view, {marked:"Health Access"}).empty?
     end
     wait_for_none_animating
@@ -54,7 +54,7 @@ Then(/^I can enable HealthKit permissions and dismiss the page$/) do
   end
 
   message = "Expected Health Access permissions view to disappear"
-  wait_for(message) do
+  bridge_wait_for(message) do
     uia_query(:view, {marked:"Health Access"}).empty?
   end
 

--- a/features/steps/health_kit_steps.rb
+++ b/features/steps/health_kit_steps.rb
@@ -1,0 +1,63 @@
+
+Then(/^I see the HealthKit modal view or Not Supported alert$/) do
+  if @supports_health_kit
+    message = "Expected Health Access permissions view to appear"
+    wait_for(message) do
+      !uia_query(:view, {marked:"Health Access"}).empty?
+    end
+    wait_for_none_animating
+  else
+    begin
+      title = alert_title
+    rescue => e
+      raise "Expected this device to support health kit: #{@supports_health_kit}\n#{e}"
+    end
+
+    expect(title).to be == "Not Supported"
+    button_title = leftmost_button_title
+    tap_alert_button(button_title)
+  end
+end
+
+Then(/^I can enable HealthKit permissions and dismiss the page$/) do
+  if @supports_health_kit
+    if RunLoop::Environment.ci?
+      pause = 10.0
+    elsif RunLoop::Environment.xtc?
+      pause = 8.0
+    else
+      pause = 3.0
+    end
+
+    if ios8?
+      # Skip the 'Sex' row because the text varies across simulator,
+      # physical devices, and form factors - the 6 plus has: Biological Sex
+      ["Body Mass Index", "Height", "Weight",
+       "Date of Birth", "Steps"].each do |mark|
+
+        uia_call(:tableView, {:scrollToElementWithName => mark})
+        sleep(pause)
+        uia_call([:switch, {:marked => mark}], {:setValue => true})
+        sleep(pause)
+      end
+
+      uia_tap_mark("Done")
+    else
+      sleep(pause)
+      uia_tap_mark("All Categories On")
+      sleep(pause)
+      uia_tap_mark("Allow")
+    end
+  else
+    # nop - device or iOS does not support health kit
+    puts "   Device or iOS version does not support HealthKit"
+  end
+
+  message = "Expected Health Access permissions view to disappear"
+  wait_for(message) do
+    uia_query(:view, {marked:"Health Access"}).empty?
+  end
+
+  wait_for_view("view marked:'page'")
+end
+

--- a/features/steps/shared_steps.rb
+++ b/features/steps/shared_steps.rb
@@ -48,6 +48,10 @@ Then(/^an NYI alert is presented$/) do
   expect(alert_title).to be == 'Not Implemented'
 end
 
+Then(/^a Not Supported alert is presented$/) do
+  expect(alert_title).to be == "Not Supported"
+end
+
 Then(/^Calabash does not dismiss the alert$/) do
   # See the comments below.
   begin

--- a/features/steps/shared_steps.rb
+++ b/features/steps/shared_steps.rb
@@ -58,68 +58,6 @@ Then(/^a Not Supported alert is presented$/) do
   expect(alert_title).to be == "Not Supported"
 end
 
-Then(/^I see the HealthKit modal view or Not Supported alert$/) do
-  if @supports_health_kit
-    message = "Expected Health Access permissions view to appear"
-    wait_for(message) do
-      !uia_query(:view, {marked:"Health Access"}).empty?
-    end
-    wait_for_none_animating
-  else
-    begin
-      title = alert_title
-    rescue => e
-      raise "Expected this device to support health kit: #{@supports_health_kit}\n#{e}"
-    end
-
-    expect(title).to be == "Not Supported"
-    button_title = leftmost_button_title
-    tap_alert_button(button_title)
-  end
-end
-
-Then(/^I can enable HealthKit permissions and dismiss the page$/) do
-  if @supports_health_kit
-    if RunLoop::Environment.ci?
-      pause = 10.0
-    elsif RunLoop::Environment.xtc?
-      pause = 8.0
-    else
-      pause = 3.0
-    end
-
-    if ios8?
-      # Skip the 'Sex' row because the text varies across simulator,
-      # physical devices, and form factors - the 6 plus has: Biological Sex
-      ["Body Mass Index", "Height", "Weight",
-       "Date of Birth", "Steps"].each do |mark|
-
-        uia_call(:tableView, {:scrollToElementWithName => mark})
-        sleep(pause)
-        uia_call([:switch, {:marked => mark}], {:setValue => true})
-        sleep(pause)
-      end
-
-      uia_tap_mark("Done")
-    else
-      sleep(pause)
-      uia_tap_mark("All Categories On")
-      sleep(pause)
-      uia_tap_mark("Allow")
-    end
-  else
-    # nop - device or iOS does not support health kit
-    puts "   Device or iOS version does not support HealthKit"
-  end
-
-  message = "Expected Health Access permissions view to disappear"
-  wait_for(message) do
-    uia_query(:view, {marked:"Health Access"}).empty?
-  end
-
-  wait_for_view("view marked:'page'")
-end
-
 Then(/^Calabash does not dismiss the alert$/) do
   # See the comments below.
   begin

--- a/features/steps/shared_steps.rb
+++ b/features/steps/shared_steps.rb
@@ -79,7 +79,7 @@ Then(/^Calabash should dismiss the alert$/) do
   #
   # If the UIA call times out, then there is probably a privacy alert.
   if RunLoop::Environment.ci?
-    timeout = 15.0
+    timeout = 30.0
   elsif RunLoop::Environment.xtc?
     timeout = 8.0
   else

--- a/features/steps/shared_steps.rb
+++ b/features/steps/shared_steps.rb
@@ -58,6 +58,31 @@ Then(/^a Not Supported alert is presented$/) do
   expect(alert_title).to be == "Not Supported"
 end
 
+Then(/^I see the HealthKit modal view or Not Supported alert$/) do
+  if @supports_health_kit
+    wait_for_none_animating
+  else
+    expect(alert_title).to be == "Not Supported"
+    button_title = leftmost_button_title
+    tap_alert_button(button_title)
+  end
+end
+
+And(/^Calabash should enable all categories and allow$/) do
+  if @supports_health_kit
+    sleep 2.0
+    uia_tap_mark("All Categories On")
+    sleep 2.0
+    uia_tap_mark("Allow")
+  else
+    # nop - device or iOS does not support health kit
+    puts "   Device or iOS version does not support HealthKit"
+  end
+
+  wait_for_none_animating
+  wait_for_view("view marked:'page'")
+end
+
 Then(/^Calabash does not dismiss the alert$/) do
   # See the comments below.
   begin

--- a/features/steps/shared_steps.rb
+++ b/features/steps/shared_steps.rb
@@ -89,13 +89,17 @@ Then(/^I can enable HealthKit permissions and dismiss the page$/) do
     end
 
     if ios8?
+      # Skip the 'Sex' row because the text varies across simulator,
+      # physical devices, and form factors - the 6 plus has: Biological Sex
       ["Body Mass Index", "Height", "Weight",
-       "Date of Birth", "Sex", "Steps"].each do |mark|
+       "Date of Birth", "Steps"].each do |mark|
+
         uia_call(:tableView, {:scrollToElementWithName => mark})
         sleep(pause)
         uia_call([:switch, {:marked => mark}], {:setValue => true})
         sleep(pause)
       end
+
       uia_tap_mark("Done")
     else
       sleep(pause)

--- a/features/steps/shared_steps.rb
+++ b/features/steps/shared_steps.rb
@@ -1,6 +1,12 @@
 
 Given(/^I can see the list of services requiring authorization$/) do
   wait_for_view("view marked:'table'")
+
+  if query("view marked:'page'", :isHealthKitAvailable).first == 1
+    @supports_health_kit = true
+  else
+    @supports_health_kit = false
+  end
 end
 
 When(/^I touch the (Contacts|Calendar|Reminders|Photos|Camera|Microphone) row$/) do |row|

--- a/features/steps/shared_steps.rb
+++ b/features/steps/shared_steps.rb
@@ -60,6 +60,10 @@ end
 
 Then(/^I see the HealthKit modal view or Not Supported alert$/) do
   if @supports_health_kit
+    message = "Expected Health Access permissions view to appear"
+    wait_for(message) do
+      !uia_query(:view, {marked:"Health Access"}).empty?
+    end
     wait_for_none_animating
   else
     begin
@@ -67,6 +71,7 @@ Then(/^I see the HealthKit modal view or Not Supported alert$/) do
     rescue => e
       raise "Expected this device to support health kit: #{@supports_health_kit}\n#{e}"
     end
+
     expect(title).to be == "Not Supported"
     button_title = leftmost_button_title
     tap_alert_button(button_title)

--- a/features/support/alerts.rb
+++ b/features/support/alerts.rb
@@ -12,11 +12,17 @@ module Permissions
         end
       end
 
-      if res.empty?
-        false
-      else
-        res.first
+      if !res.is_a?(Hash)
+        fail("Expected `uia` to return a Hash but found #{res}")
       end
+
+      status = res["status"]
+
+      if status != "success"
+        fail("Expected `uia` to exist with 'success' but found #{status}")
+      end
+
+      res["value"]
     end
 
     def alert_button_exists?(button_title)


### PR DESCRIPTION
### Motivation

* **Privacy: problems dismissing health kit slide over** [#374](https://github.com/calabash/run_loop/issues/374)
* **[iOS] User unable to run tests on some iPhone devices due to HealthKit permission popup** [#748](https://github.com/xamarin/test-cloud-operations/issues/748)

The UIAutomation `onAlert()` method is not called when this modal permissions view is presented, so we cannot dismiss it automatically.

I have provided an example feature that shows how to handle:

1. Devices and iOS versions that are not support (iOS < 8 and iPads)
2. Dismissing the pop-over with `uia_*` calls.

### TODO

- [x] Sensible sleeps for interacting with the slide over
- [x] Detect the slide over; did it pop?  This will be important for tests on devices that already have HealthKit enabled.
- [x] Handle UI diff between iOS 8 and iOS 9