### PR TITLE
Fix build errors on Xcode 10.3

### DIFF
--- a/Permissions.xcodeproj/project.pbxproj
+++ b/Permissions.xcodeproj/project.pbxproj
@@ -23,7 +23,6 @@
 		F54CCC291B84D79C0007F68D /* RowDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = F54CCC281B84D79C0007F68D /* RowDetails.m */; };
 		F55CD5FE1DF9B0F800F2CF68 /* MBFingerTipWindow.m in Sources */ = {isa = PBXBuildFile; fileRef = F55CD5FC1DF9B0F800F2CF68 /* MBFingerTipWindow.m */; };
 		F55CD5FF1DF9B10B00F2CF68 /* FINGERTIPS_LICENSE.md in Resources */ = {isa = PBXBuildFile; fileRef = F55CD5FA1DF9B0F800F2CF68 /* FINGERTIPS_LICENSE.md */; };
-		F57605171BC57F6A00E89C97 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = F57605151BC57F6A00E89C97 /* LaunchScreen.xib */; };
 		F5F1A8E41C7B54BB00BF8D6F /* HealthKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F5F1A8E31C7B54BB00BF8D6F /* HealthKit.framework */; };
 /* End PBXBuildFile section */
 
@@ -240,6 +239,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 				fr,
@@ -271,7 +271,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F57605171BC57F6A00E89C97 /* LaunchScreen.xib in Resources */,
 				92D56A1918A38F0300B4369B /* Images.xcassets in Resources */,
 				92D56A0B18A38F0300B4369B /* InfoPlist.strings in Resources */,
 				92D56A1418A38F0300B4369B /* Main.storyboard in Resources */,

--- a/features/steps/shared_steps.rb
+++ b/features/steps/shared_steps.rb
@@ -250,7 +250,7 @@ Then(/^I see the Photos alert$/) do
   if uia_available?
     # Impossible to wait for the alert because it is automatically dismissed
   else
-    if ios11?
+    if ios_gte_11?
       # Surprise!  No alert for Photos in iOS 11.
     else
       # With DeviceAgent, we can wait for the alert.  It is the next query or
@@ -288,7 +288,7 @@ And(/^I can dismiss the Photo Roll by touching Cancel$/) do
     # Sleep for a long time to make sure the final touch actually happens.
     sleep(timeout_for_env)
   end
-  if ios11?
+  if ios_gte_11?
     # Surprise!  There is no Photos alert in iOS 11
   else
     wait_for_alert_dismissed_text

--- a/features/steps/shared_steps.rb
+++ b/features/steps/shared_steps.rb
@@ -251,7 +251,7 @@ Then(/^I see the Photos alert$/) do
     # Impossible to wait for the alert because it is automatically dismissed
   else
     if ios_gte_11?
-      # Surprise!  No alert for Photos in iOS 11.
+      # Surprise!  No alert for Photos in iOS 11+.
     else
       # With DeviceAgent, we can wait for the alert.  It is the next query or
       # gesture that causes the alert to be automatically dismissed.
@@ -288,7 +288,7 @@ And(/^I can dismiss the Photo Roll by touching Cancel$/) do
     # Sleep for a long time to make sure the final touch actually happens.
     sleep(timeout_for_env)
   end
-  if ios_gte_11?
+  if ios11?
     # Surprise!  There is no Photos alert in iOS 11
   else
     wait_for_alert_dismissed_text


### PR DESCRIPTION
**Issue:**
`make app` fails with errors:
```
❌  error: Multiple commands produce 'Permissions/build/app/Build/Products/Debug-iphonesimulator/Permissions.app/Base.lproj/LaunchScreen~ipad.nib':
❌  error: Multiple commands produce 'Permissions/build/app/Build/Products/Debug-iphonesimulator/Permissions.app/Base.lproj/LaunchScreen.nib':
❌  error: Multiple commands produce 'Permissions/build/app/Build/Products/Debug-iphonesimulator/Permissions.app/Base.lproj/LaunchScreen~iphone.nib':
❌  error: invalid task ('StripNIB build/app/Build/Products/Debug-iphonesimulator/Permissions.app/Base.lproj/LaunchScreen.nib') with mutable output but no other virtual output node (in target 'Permissions')
❌  error: invalid task ('StripNIB build/app/Build/Products/Debug-iphonesimulator/Permissions.app/Base.lproj/LaunchScreen~ipad.nib') with mutable output but no other virtual output node (in target 'Permissions')
❌  error: invalid task ('StripNIB build/app/Build/Products/Debug-iphonesimulator/Permissions.app/Base.lproj/LaunchScreen~iphone.nib') with mutable output but no other virtual output node (in target 'Permissions')
```

**Fix:**
Remove `LaunchScreen.xib` from section `Build Phases -> Copy Bundle Resources`
Also I have fixed photos test that constantly fails on iOS 12, 13. Need to extend iOS 11 approach to iOS 12, 13 too