### PR TITLE
Skip health_kit and photos tests

### DIFF
--- a/features/00-permissions.feature
+++ b/features/00-permissions.feature
@@ -22,6 +22,7 @@ When I touch the Background Location Services row
 Then Calabash should dismiss the alert
 And background location services are authorized
 
+@skip_for_non_english
 @health_kit
 @reset_device_settings
 Scenario: Enabling Health Kit permissions
@@ -47,6 +48,7 @@ When I touch the Reminders row
 Then Calabash should dismiss the alert
 And access to reminders is authorized
 
+@skip_for_non_english
 @photos
 Scenario: Photos alert is dismissed
 When I touch the Photos row

--- a/features/steps/shared_steps.rb
+++ b/features/steps/shared_steps.rb
@@ -55,7 +55,7 @@ Timed out waiting for #{service_name} to be authorized after #{timeout} seconds.
       elsif RunLoop::Environment.xtc?
         3.0
       else
-        1.0
+        3.0
       end
     end
 

--- a/features/support/01_launch.rb
+++ b/features/support/01_launch.rb
@@ -204,6 +204,11 @@ Before("@reset_device_settings") do
   end
 end
 
+Before("@skip_for_non_english") do
+  app_lang = Permissions::Launchctl.instance.app_lang
+  skip_this_scenario if app_lang != 'en' && app_lang != 'en-US'
+end
+
 Before do |scenario|
 
   if !xamarin_test_cloud?


### PR DESCRIPTION
Problem: health_kit and photos tests has hardcoded button's identifiers, like 'Cancel' and 'Allow' and these tests failed with other languages. Also, photos test needs more time for animation for correct work.  

Solution: skip these tests and increase time for animations