### PR TITLE
Fix test failures shared_steps

### DIFF
--- a/features/00-permissions.feature
+++ b/features/00-permissions.feature
@@ -54,7 +54,6 @@ Scenario: Photos alert is dismissed
 When I touch the Photos row
 Then I see the Photos alert
 Then I wait for the Photo Roll to finish animating on
-And for Calabash to dismiss the Photo Alert
 And I can dismiss the Photo Roll by touching Cancel
 Then I verify that I have access to Photos
 

--- a/features/steps/shared_steps.rb
+++ b/features/steps/shared_steps.rb
@@ -105,27 +105,15 @@ Timed out waiting for In-App Alert to disappear after #{timeout} seconds
     end
 
     def springboard_alert_visible?
-      if uia_available?
-        result = uia('uia.alert() != null')
 
-        status = result["status"]
-
-        if status != "success"
-          fail("Expected `uia` to exist with 'success' but found #{status}")
-        end
-        result["value"]
-      else
-        device_agent.springboard_alert_visible?
-      end
+      device_agent.springboard_alert_visible?
     end
 
     def wait_for_springboard_alert
       timeout = timeout_for_env
 
       message = %Q[
-
 Timed out waiting for Springboard Alert after #{timeout} seconds
-
 ]
 
       bridge_wait_for(message, {:timeout => timeout}) do
@@ -247,16 +235,13 @@ When(/^I touch the Photos row$/) do
 end
 
 Then(/^I see the Photos alert$/) do
-  if uia_available?
-    # Impossible to wait for the alert because it is automatically dismissed
+
+  if ios_gte_11?
+    # Surprise!  No alert for Photos in iOS 11+.
   else
-    if ios_gte_11?
-      # Surprise!  No alert for Photos in iOS 11+.
-    else
-      # With DeviceAgent, we can wait for the alert.  It is the next query or
-      # gesture that causes the alert to be automatically dismissed.
-      wait_for_springboard_alert
-    end
+    # With DeviceAgent, we can wait for the alert.  It is the next query or
+    # gesture that causes the alert to be automatically dismissed.
+    wait_for_springboard_alert
   end
 end
 
@@ -270,24 +255,12 @@ Then(/^the Photo Roll is visible behind the alert$/) do
   wait_for_view("* marked:'Cancel'")
 end
 
-And(/^for Calabash to dismiss the Photo Alert$/) do
-  # DeviceAgent will dismiss the alert by attempting to touch the Cancel button.
-  if !uia_available?
-    touch("* marked:'Cancel'")
-  end
-end
-
 And(/^I can dismiss the Photo Roll by touching Cancel$/) do
-  if uia_available?
-    # Waiting for no alert does not work.
-    sleep(timeout_for_env)
-    touch("* marked:'Cancel'")
-    sleep(timeout_for_env)
-  else
-    # DeviceAgent does not like interacting with the Photo Roll animations.
-    # Sleep for a long time to make sure the final touch actually happens.
-    sleep(timeout_for_env)
-  end
+  # Waiting for no alert does not work.
+  sleep(timeout_for_env)
+  device_agent.touch({marked: "Cancel"})
+  sleep(timeout_for_env)
+
   if ios11?
     # Surprise!  There is no Photos alert in iOS 11
   else
@@ -302,18 +275,16 @@ end
 Then(/^I verify that I have access to Photos$/) do
   expect_action_label_ready_for_next_alert
   tap_row("photos")
-  wait_for_view("* marked:'Cancel'")
+  device_agent.wait_for_view({marked: "Cancel"})
 
-  if !uia_available?
-    query = "* {text CONTAINS 'does not have access' }"
-    if !query(query).empty?
-      fail("Expected to see the photo roll")
-    end
+  query = "* {text CONTAINS 'does not have access' }"
+  if !query(query).empty?
+    fail("Expected to see the photo roll")
   end
 
   sleep(timeout_for_env)
 
-  touch("* marked:'Cancel'")
+  device_agent.touch({marked: "Cancel"})
   wait_for_view("* marked:'action label'")
 end
 
@@ -369,14 +340,12 @@ And(/^Calabash backed by UIA automatically dismisses the alert$/) do
 end
 
 But(/^Calabash backed by DeviceAgent will not auto dismiss because it is fake$/) do
-  if !uia_available?
-    wait_for_animations
-    sleep(0.4)
-    touch("* marked:'OK'")
-    wait_for_animations
-    wait_for_no_alert
-    wait_for_alert_dismissed_text
-  end
+  wait_for_animations
+  sleep(0.4)
+  device_agent.touch({marked: "OK"})
+  wait_for_animations
+  wait_for_no_alert
+  wait_for_alert_dismissed_text
 end
 
 When(/^I touch the APNS row$/) do
@@ -421,18 +390,14 @@ Then(/^I see the HealthKit modal view or Not Supported alert$/) do
   if @supports_health_kit
     message = "Expected Health Access permissions view to appear"
     bridge_wait_for(message) do
-      if uia_available?
-        !uia_query(:view, {marked:"Health Access"}).empty?
-      else
-        !device_agent.query({marked: "Health Access"}).empty?
-      end
+      !device_agent.query({marked: "Health Access"}).empty?
     end
     wait_for_none_animating
   else
     wait_for_alert
-    wait_for_none_animating
-    sleep(1.0)
-    touch("* marked:'Dismiss'")
+    # wait_for_none_animating
+    device_agent.touch({marked: "Dismiss"})
+    # touch("* marked:'Dismiss'")
     wait_for_no_alert
   end
 end
@@ -451,46 +416,23 @@ Then(/^I can enable HealthKit permissions and dismiss the page$/) do
       pause = 3.0
     end
 
-    if uia_available?
-      if ios8?
-        # Just enable some rows.  What is visible depends on iOS version
-        # and form factor.
-        ["Body Mass Index", "Height", "Weight"].each do |mark|
 
-          uia_call(:tableView, {:scrollToElementWithName => mark})
-          sleep(pause)
-          uia_call([:switch, {:marked => mark}], {:setValue => true})
-          sleep(pause)
-        end
-
-        uia_tap_mark("Done")
-      else
-        sleep(pause)
-        uia_tap_mark("All Categories On")
-        sleep(pause)
-        uia_tap_mark("Allow")
-      end
-    else
-      sleep(pause)
-      device_agent.touch({marked: "Turn All Categories On"})
-      sleep(pause)
-      device_agent.touch({marked: "Allow"})
-
-      # Remove when the Cannot wait for "Health Access" view to disappear
-      # issue is resolved.
-      # https://jira.xamarin.com/browse/TCFW-584
-      sleep(pause)
-    end
+    sleep(pause)
+    device_agent.touch({marked: "Turn All Categories On"})
+    sleep(pause)
+    device_agent.touch({marked: "Allow"})
+    # Remove when the Cannot wait for "Health Access" view to disappear
+    # issue is resolved.
+    # https://jira.xamarin.com/browse/TCFW-584
+    sleep(pause)
 
     timeout = timeout_for_env
     message = %Q[
-
 Waited for #{timeout} seconds for the Health Access permissions view to disappear
-
 ]
     bridge_wait_for(message, {:timeout => timeout} ) do
       if uia_available?
-        uia_query(:view, {marked:"Health Access"}).empty?
+        device_agent.query({marked: "Health Access"}).empty?
       else
         # https://jira.xamarin.com/browse/TCFW-584
         # Cannot wait for the "Health Access" view to disappear.

--- a/features/steps/shared_steps.rb
+++ b/features/steps/shared_steps.rb
@@ -285,7 +285,7 @@ Then(/^I verify that I have access to Photos$/) do
   sleep(timeout_for_env)
 
   device_agent.touch({marked: "Cancel"})
-  wait_for_view("* marked:'action label'")
+  device_agent.wait_for_view(marked:"action label")
 end
 
 When(/^I touch the (Facebook|Twitter) row$/) do |row|
@@ -395,9 +395,8 @@ Then(/^I see the HealthKit modal view or Not Supported alert$/) do
     wait_for_none_animating
   else
     wait_for_alert
-    # wait_for_none_animating
+    wait_for_none_animating
     device_agent.touch({marked: "Dismiss"})
-    # touch("* marked:'Dismiss'")
     wait_for_no_alert
   end
 end

--- a/features/steps/shared_steps.rb
+++ b/features/steps/shared_steps.rb
@@ -285,7 +285,7 @@ Then(/^I verify that I have access to Photos$/) do
   sleep(timeout_for_env)
 
   device_agent.touch({marked: "Cancel"})
-  device_agent.wait_for_view(marked:"action label")
+  wait_for_view("* marked:'action label'")
 end
 
 When(/^I touch the (Facebook|Twitter) row$/) do |row|


### PR DESCRIPTION
Fix failure tests with rewriting logic from calabash-ios (touch) to DeviceAgent (device_agent.touch). Also ui available condition was deleted from shared_steps